### PR TITLE
Fixed the NullReferenceException when I clicked the backup or restore calibration when the reading data from the GD77 TRX.

### DIFF
--- a/Extras/OpenGD77/OpenGD77Form.cs
+++ b/Extras/OpenGD77/OpenGD77Form.cs
@@ -1370,6 +1370,12 @@ namespace DMR
 			btnRestoreFlash.Enabled = show;
 			btnReadCodeplug.Enabled = show;
 			btnWriteCodeplug.Enabled = show;
+			btnBackupCalibration.Enabled = show;
+			btnRestoreCalibration.Enabled = show;
+			btnOpenFile.Enabled = show;
+			btnBackupMCUROM.Enabled = show;
+			btnDownloadScreenGrab.Enabled = show;
+			btnPlayTune.Enabled = show;
 		}
 
 		private void OpenGD77Form_Load(object sender, EventArgs e)


### PR DESCRIPTION
The backup/restore calibration was enabled on the "OpenGD77 Support" window when the data was reading from TRX. I fixed this for all enabled buttons when we reading/uploading data from/to TRX.

BTW. According to "Scout Rule", I made the minor refactoring of the method "enableDisableAllButtons" - I renamed the method name according to C# convention: "EnableDisableAllButtons".