### PR TITLE
Typo corr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 # OpenGD77CPS
-CPS for the OpenGD77 and OpenDM1801 firmware based on the Radioddity CPS Comminity Edition (which was originally based on the official Radioddity CPS).
-
 CPS for the OpenGD77 and OpenDM1801 firmware based on the Radioddity CPS Community Edition (which was originally based on the official Radioddity CPS).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # OpenGD77CPS
 CPS for the OpenGD77 and OpenDM1801 firmware based on the Radioddity CPS Comminity Edition (which was originally based on the official Radioddity CPS).
 
+CPS for the OpenGD77 and OpenDM1801 firmware based on the Radioddity CPS Community Edition (which was originally based on the official Radioddity CPS).


### PR DESCRIPTION
One minor typo corrected: 'Community' to 'Community'.