### PR TITLE
Fixed com port look-up on some non-English platforms. Resolves #15.

### DIFF
--- a/Extras/SetupDiWrap.cs
+++ b/Extras/SetupDiWrap.cs
@@ -14,7 +14,7 @@ namespace DMR
 			Guid[] guids = GetClassGUIDs(className);
 
 			System.Text.RegularExpressions.Regex friendlyNameToComPort =
-				new System.Text.RegularExpressions.Regex(@".? \((COM\d+)\)$");  // "..... (COMxxx)" -> COMxxxx
+				new System.Text.RegularExpressions.Regex(@".? \((COM\d+)\)\s?$");  // "..... (COMxxx)" -> COMxxxx
 
 			foreach (Guid guid in guids)
 			{


### PR DESCRIPTION
It hasn't been possible to set or open the com port on some non-English platforms (tested on the Czech Windows 7). The problem was in the additional space at the end of the port name which mismatched the regular expression used to extract the short name.

Fixed by adding optional blank character at the end of the regular expression.